### PR TITLE
Update README with config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Options:
 
 ## Example Config
 
+Save config as `.augre/config.toml` in the directory that needs to be reviewed
+
 ```toml
 mode = "LocalGpu"
 model_url = "https://huggingface.co/TheBloke/CodeLlama-13B-Instruct-GGML/resolve/main/codellama-13b-instruct.ggmlv3.Q3_K_M.bin"


### PR DESCRIPTION
Mention config path clearly in README for new users (who may not know about rust based tools) to set up augre easily. 

[[1]](https://github.com/twitchax/augre/issues/2#issuecomment-2121388915)