### PR TITLE
Improve documentation for Windows installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,21 @@ An LLM-powered (CodeLlama or OpenAI) local diff code review tool.
 
 Windows:
 
+1. Open PowerShell as an Administrator.
+
+2. Download and insall augre:
 ```powershell
 $ iwr -uri https://github.com/twitchax/augre/releases/latest/download/augre_x86_64-pc-windows-gnu.zip -OutFile "augre_x86_64-pc-windows-gnu.zip"
 $ Expand-Archive augre_x86_64-pc-windows-gnu.zip -DestinationPath "$env:LOCALAPPDATA\Programs\augre"
+```
+3. Add the augre directory to your PATH.
+```powershell
+$augre_path = "$env:LOCALAPPDATA\Programs\augre"
+$current_path = [Environment]::GetEnvironmentVariable("PATH", "User")
+if ($current_path -notlike "*$augre_path*") {
+    [Environment]::SetEnvironmentVariable("PATH", "$current_path;$augre_path", "User")
+    $env:PATH = "$env:PATH;$augre_path"
+}
 ```
 
 Mac OS (Apple Silicon):

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ An LLM-powered (CodeLlama or OpenAI) local diff code review tool.
 Windows:
 
 ```powershell
-$ iwr https://github.com/twitchax/augre/releases/latest/download/augre_x86_64-pc-windows-gnu.zip
+$ iwr -uri https://github.com/twitchax/augre/releases/latest/download/augre_x86_64-pc-windows-gnu.zip -OutFile "augre_x86_64-pc-windows-gnu.zip"
 $ Expand-Archive augre_x86_64-pc-windows-gnu.zip -DestinationPath C:\Users\%USERNAME%\AppData\Local\Programs\augre
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Windows:
 
 ```powershell
 $ iwr -uri https://github.com/twitchax/augre/releases/latest/download/augre_x86_64-pc-windows-gnu.zip -OutFile "augre_x86_64-pc-windows-gnu.zip"
-$ Expand-Archive augre_x86_64-pc-windows-gnu.zip -DestinationPath C:\Users\%USERNAME%\AppData\Local\Programs\augre
+$ Expand-Archive augre_x86_64-pc-windows-gnu.zip -DestinationPath "$env:LOCALAPPDATA\Programs\augre"
 ```
 
 Mac OS (Apple Silicon):


### PR DESCRIPTION
The following Windows installation instructions have been improved:
- The `iwr` command now specifies the output file name explicitly to ensure proper file creation.
- Replaced `%USERNAME%` with `$env:LOCALAPPDATA` to correctly locate the user's Local AppData folder, fixing an issue with incorrect installation directory.
- Added a note to run PowerShell as administrator and instructions to add augre to PATH for easier command access.